### PR TITLE
Create replacement databases

### DIFF
--- a/synapsegenie/__main__.py
+++ b/synapsegenie/__main__.py
@@ -2,6 +2,7 @@
 # noqa pylint: disable=line-too-long
 """synapsegenie cli"""
 import argparse
+from datetime import date
 import logging
 
 import synapseclient
@@ -93,16 +94,12 @@ def process(syn, project_id, center=None, pemfile=None,
     """Process files"""
     # Get the Synapse Project where data is stored
     # Should have annotations to find the table lookup
-    project = syn.get(project_id)
-    database_to_synid_mapping_synid = project.annotations.get("dbMapping", "")
-
-    databaseToSynIdMapping = syn.tableQuery(
-        'SELECT * FROM {}'.format(database_to_synid_mapping_synid[0]))
-    databaseToSynIdMappingDf = databaseToSynIdMapping.asDataFrame()
+    db_mapping_info = process_functions.get_dbmapping(syn, project_id)
+    database_mappingdf = db_mapping_info['df']
 
     center_mapping_id = process_functions.getDatabaseSynId(
         syn, "centerMapping",
-        databaseToSynIdMappingDf=databaseToSynIdMappingDf
+        databaseToSynIdMappingDf=database_mappingdf
     )
 
     center_mapping = syn.tableQuery(f'SELECT * FROM {center_mapping_id}')
@@ -128,7 +125,7 @@ def process(syn, project_id, center=None, pemfile=None,
     for process_center in centers:
         input_to_database.center_input_to_database(
             syn, project_id, process_center,
-            only_validate, databaseToSynIdMappingDf,
+            only_validate, database_mappingdf,
             center_mapping_df,
             delete_old=delete_old,
             format_registry=format_registry,
@@ -136,7 +133,7 @@ def process(syn, project_id, center=None, pemfile=None,
         )
 
     error_tracker_synid = process_functions.getDatabaseSynId(
-        syn, "errorTracker", databaseToSynIdMappingDf=databaseToSynIdMappingDf
+        syn, "errorTracker", databaseToSynIdMappingDf=database_mappingdf
     )
     # Only write out invalid reasons if the center
     # isnt specified and if only validate
@@ -145,6 +142,22 @@ def process(syn, project_id, center=None, pemfile=None,
         write_invalid_reasons.write_invalid_reasons(
             syn, center_mapping_df, error_tracker_synid
         )
+
+
+def replace_db_cli_wrapper(syn, args):
+    """Replace existing db with new empty db"""
+    db_mapping_info = process_functions.get_dbmapping(syn, args.project_id)
+    database_mappingdf = db_mapping_info['df']
+    if args.filetype not in database_mappingdf['Database'].tolist():
+        raise ValueError("Must specify existing database type")
+    today = date.today()
+    table_name = f'{args.table_name} - {today}'
+    new_tables = process_functions.create_new_fileformat_table(
+        syn, args.filetype, table_name, args.project_id,
+        args.archive_projectid
+    )
+    print(new_tables['newdb_ent'])
+
 
 def build_parser():
     """Build CLI parsers"""
@@ -237,6 +250,23 @@ def build_parser():
         help="Add debug mode to synapse"
     )
     parser_process.set_defaults(func=process_cli_wrapper)
+
+    parser_replace_db = subparsers.add_parser(
+        'replace-db',
+        help='Replace existing database with new empty database',
+        parents=[parent_parser]
+    )
+    parser_replace_db.add_argument('filetype',
+                                   help='Database type to replace')
+    parser_replace_db.add_argument(
+        'archive_projectid',
+        help='Synapse id of project to archive table'
+    )
+    parser_replace_db.add_argument(
+        'table_name',
+        help='New table name.  Will have todays date appened to it.'
+    )
+    parser_replace_db.set_defaults(func=replace_db_cli_wrapper)
 
     return parser
 

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -313,65 +313,6 @@ def processfiles(syn, validfiles, center, path_to_genie,
 
     logger.info("ALL DATA STORED IN DATABASE")
 
-# def _create_maf_db(syn, foo):
-#     maf_database_ent = syn.get(maf_database_synid)
-#     print(maf_database_ent)
-#     maf_columns = list(syn.getTableColumns(maf_database_synid))
-#     schema = synapseclient.Schema(
-#         name='Narrow MAF {current_time} Database'.format(
-#             current_time=time.time()),
-#         columns=maf_columns,
-#         parent=process_functions.getDatabaseSynId(
-#             syn, "main",
-#             databaseToSynIdMappingDf=database_synid_mappingdf))
-#     schema.primaryKey = maf_database_ent.primaryKey
-#     new_maf_database = syn.store(schema)
-
-# TODO: Should split this into 3 funcitons
-# so that unit tests are easier to write
-
-
-def create_and_archive_maf_database(syn, database_synid_mappingdf):
-    '''
-    Creates new MAF database and archives the old database in the staging site
-
-    Args:
-        syn: Synapse object
-        databaseToSynIdMappingDf: Database to synapse id mapping dataframe
-
-    Return:
-        Editted database to synapse id mapping dataframe
-    '''
-    maf_database_synid = process_functions.getDatabaseSynId(
-        syn, "vcf2maf", project_id=None, databaseToSynIdMappingDf=database_synid_mappingdf)
-    maf_database_ent = syn.get(maf_database_synid)
-    maf_columns = list(syn.getTableColumns(maf_database_synid))
-    schema = synapseclient.Schema(
-        name='Narrow MAF {current_time} Database'.format(
-            current_time=time.time()),
-        columns=maf_columns,
-        parent=process_functions.getDatabaseSynId(
-            syn, "main", databaseToSynIdMappingDf=database_synid_mappingdf))
-    schema.primaryKey = maf_database_ent.primaryKey
-    new_maf_database = syn.store(schema)
-    # Store in the new database synid
-    database_synid_mappingdf['Id'][
-        database_synid_mappingdf[
-            'Database'] == 'vcf2maf'] = new_maf_database.id
-
-    vcf2maf_mappingdf = database_synid_mappingdf[
-        database_synid_mappingdf['Database'] == 'vcf2maf']
-    # vcf2maf_mappingdf['Id'][0] = newMafDb.id
-    syn.store(synapseclient.Table("syn10967259", vcf2maf_mappingdf))
-    # Move and archive old mafdatabase (This is the staging synid)
-    maf_database_ent.parentId = "syn7208886"
-    maf_database_ent.name = "ARCHIVED " + maf_database_ent.name
-    syn.store(maf_database_ent)
-    # maf_database_synid = new_maf_database.id
-    # Remove can download permissions from project GENIE team
-    syn.setPermissions(new_maf_database.id, 3326313, [])
-    return(database_synid_mappingdf)
-
 
 def append_duplication_errors(duplicated_filesdf, user_message_dict):
     """Duplicated files can occur because centers can upload files with the

--- a/synapsegenie/process_functions.py
+++ b/synapsegenie/process_functions.py
@@ -8,9 +8,11 @@ import requests
 from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 import tempfile
+import time
 
 import pandas as pd
 import synapseclient
+from synapseclient import Synapse
 
 # try:
 #   from urllib.request import urlopen

--- a/synapsegenie/process_functions.py
+++ b/synapsegenie/process_functions.py
@@ -684,3 +684,128 @@ def synLogin(pemfile_path, debug=False):
         syn = synapseclient.Synapse(debug=debug)
         syn.login(os.environ['GENIE_USER'], genie_pass)
     return(syn)
+
+
+def _create_schema(syn, table_name, parentid, columns=None, annotations=None):
+    """Creates Table Schema
+    Args:
+        syn: Synapse object
+        table_name: Name of table
+        parentid: Project synapse id
+        columns: Columns of Table
+        annotations: Dictionary of annotations to add
+    Returns:
+        Schema
+    """
+    schema = synapseclient.Schema(name=table_name,
+                                  columns=columns,
+                                  parent=parentid,
+                                  annotations=annotations)
+    new_schema = syn.store(schema)
+    return new_schema
+
+
+def _update_database_mapping(syn, database_synid_mappingdf,
+                             database_mapping_synid,
+                             fileformat, new_tableid):
+    """Updates database to synapse id mapping table
+    Args:
+        syn: Synapse object
+        database_synid_mappingdf: Database to synapse id mapping dataframe
+        database_mapping_synid: Database to synapse id table id
+        fileformat: File format updated
+        new_tableid: New file format table id
+    Returns:
+        Updated Table object
+    """
+    fileformat_ind = database_synid_mappingdf['Database'] == fileformat
+    # Store in the new database synid
+    database_synid_mappingdf['Id'][fileformat_ind] = new_tableid
+    # Only update the one row
+    to_update_row = database_synid_mappingdf[fileformat_ind]
+
+    updated_table = syn.store(synapseclient.Table(database_mapping_synid,
+                                                  to_update_row))
+    return database_synid_mappingdf
+
+
+# TODO: deprecate once move function is out of the cli into the
+# client master branch
+def _move_entity(syn, ent, parentid, name=None):
+    """Moves an entity (works like linux mv)
+    Args:
+        syn: Synapse object
+        ent: Synapse Entity
+        parentid: Synapse Project id
+        name: New Entity name if a new name is desired
+    Returns:
+        Moved Entity
+    """
+    ent.parentId = parentid
+    if name is not None:
+        ent.name = name
+    moved_ent = syn.store(ent)
+    return moved_ent
+
+
+def get_dbmapping(syn: Synapse, projectid: str) -> dict:
+    """Gets database mapping information
+    Args:
+        syn: Synapse connection
+        projectid: Project id where new data lives
+    Returns:
+        {'synid': database mapping syn id,
+         'df': database mapping pd.DataFrame}
+    """
+    project_ent = syn.get(projectid)
+    dbmapping_synid = project_ent.annotations.get("dbMapping", "")[0]
+    database_mapping = syn.tableQuery(f'select * from {dbmapping_synid}')
+    database_mappingdf = database_mapping.asDataFrame()
+    return {'synid': dbmapping_synid,
+            'df': database_mappingdf}
+
+
+def create_new_fileformat_table(syn: Synapse,
+                                file_format: str,
+                                newdb_name: str,
+                                projectid: str,
+                                archive_projectid: str) -> dict:
+    """Creates new database table based on old database table and archives
+    old database table
+    Args:
+        syn: Synapse object
+        file_format: File format to update
+        newdb_name: Name of new database table
+        projectid: Project id where new database should live
+        archive_projectid: Project id where old database should be moved
+    Returns:
+        {"newdb_ent": New database synapseclient.Table,
+         "newdb_mappingdf": new databse pd.DataFrame,
+         "moved_ent": old database synpaseclient.Table}
+    """
+    db_info = get_dbmapping(syn, projectid)
+    database_mappingdf = db_info['df']
+    dbmapping_synid = db_info['synid']
+
+    olddb_synid = getDatabaseSynId(syn, file_format,
+                                   databaseToSynIdMappingDf=database_mappingdf)
+    olddb_ent = syn.get(olddb_synid)
+    olddb_columns = list(syn.getTableColumns(olddb_synid))
+
+    newdb_ent = _create_schema(syn, table_name=newdb_name,
+                               columns=olddb_columns,
+                               parentid=projectid,
+                               annotations=olddb_ent.annotations)
+
+    newdb_mappingdf = _update_database_mapping(syn, database_mappingdf,
+                                               dbmapping_synid,
+                                               file_format, newdb_ent.id)
+    # Automatically rename the archived entity with ARCHIVED
+    # This will attempt to resolve any issues if the table already exists at
+    # location
+    new_table_name = f"ARCHIVED {time.time()}-{olddb_ent.name}"
+    moved_ent = _move_entity(syn, olddb_ent, archive_projectid,
+                             name=new_table_name)
+    return {"newdb_ent": newdb_ent,
+            "newdb_mappingdf": newdb_mappingdf,
+            "moved_ent": moved_ent}

--- a/synapsegenie/process_functions.py
+++ b/synapsegenie/process_functions.py
@@ -1,5 +1,6 @@
 """Processing functions"""
 import ast
+from datetime import date
 import logging
 import os
 import tempfile
@@ -804,7 +805,7 @@ def create_new_fileformat_table(syn: Synapse,
     # Automatically rename the archived entity with ARCHIVED
     # This will attempt to resolve any issues if the table already exists at
     # location
-    new_table_name = f"ARCHIVED {time.time()}-{olddb_ent.name}"
+    new_table_name = f"ARCHIVED {date.today()}-{olddb_ent.name}"
     moved_ent = _move_entity(syn, olddb_ent, archive_projectid,
                              name=new_table_name)
     return {"newdb_ent": newdb_ent,

--- a/synapsegenie/process_functions.py
+++ b/synapsegenie/process_functions.py
@@ -1,16 +1,15 @@
+"""Processing functions"""
 import ast
-from Crypto.PublicKey import RSA
-import datetime
-import json
 import logging
 import os
-import requests
-from requests.adapters import HTTPAdapter
-from requests.packages.urllib3.util.retry import Retry
 import tempfile
 import time
 
+from Crypto.PublicKey import RSA
 import pandas as pd
+import requests
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
 import synapseclient
 from synapseclient import Synapse
 

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -298,41 +298,6 @@ def test_error_check_existing_file_status():
             emptydf, emptydf, entities)
 
 
-def test_create_and_archive_maf_database():
-    '''
-    Test the creation and archive of the maf database
-    '''
-    table_ent = synapseclient.Entity(
-        parentId="syn123", name="foo", primaryKey=['annot'], id='syn12345')
-    new_maf_ent = synapseclient.Entity(id="syn2222")
-    database_synid_mappingdf = pd.DataFrame({
-        'Database': ['vcf2maf', 'main'],
-        'Id': ['syn12345', 'syn23455']})
-
-    with patch.object(syn, "store",
-                      return_value=new_maf_ent) as patch_syn_store,\
-         patch.object(syn, "setPermissions",
-                      return_value=None) as patch_syn_set_permissions,\
-         patch.object(syn, "get",
-                      return_value=table_ent) as patch_syn_get,\
-         patch.object(syn, "getTableColumns",
-                      return_value=['foo', 'ddooo']) as patch_syn_get_table_columns:
-
-        database_mappingdf = input_to_database.create_and_archive_maf_database(
-            syn, database_synid_mappingdf)
-
-        assert database_mappingdf['Id'][
-            database_mappingdf['Database'] == 'vcf2maf'].values[0] \
-            == new_maf_ent.id
-        assert database_mappingdf['Id'][
-            database_mappingdf['Database'] == 'main'].values[0] == 'syn23455'
-        patch_syn_get_table_columns.assert_called_once_with('syn12345')
-        patch_syn_get.assert_called_once_with('syn12345')
-        assert patch_syn_store.call_count == 3
-        patch_syn_set_permissions.assert_called_once_with(
-            new_maf_ent.id, 3326313, [])
-
-
 def test_valid_validatefile():
     '''
     Tests the behavior of a file that gets validated that becomes

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -319,3 +319,115 @@ def test_get_syntabledf():
         df = synapsegenie.process_functions.get_syntabledf(syn, querystring)
         patch_syn_tablequery.assert_called_once_with(querystring)
         assert df.equals(arg.asDataFrame())
+
+
+def test__create_schema():
+    """Tests calling of create schema"""
+    table_name = str(uuid.uuid1())
+    parentid = str(uuid.uuid1())
+    columns = [str(uuid.uuid1())]
+    annotations = {"foo": "bar"}
+
+    schema = synapseclient.Schema(table_name, columns=columns,
+                                  parent=parentid, annotations=annotations)
+    with patch.object(syn, "store",
+                      return_value=schema) as patch_syn_store:
+
+        new_schema = process_functions._create_schema(syn, table_name, parentid,
+                                                      columns=columns,
+                                                      annotations=annotations)
+        patch_syn_store.assert_called_once_with(schema)
+        assert new_schema == schema
+
+
+def test__update_database_mapping():
+    """Tests updates database mapping"""
+    fileformat = str(uuid.uuid1())
+    database_mappingdf = pd.DataFrame({'Database': [fileformat, "foo"],
+                                       "Id": ['11111', "bar"]})
+    database_mapping_synid = str(uuid.uuid1())
+    new_tableid = str(uuid.uuid1())
+    expected_mapdf = pd.DataFrame({'Database': [fileformat, "foo"],
+                                   "Id": [new_tableid, "bar"]})
+    with patch.object(syn, "store") as patch_syn_store:
+        newdb = process_functions._update_database_mapping(syn, database_mappingdf,
+                                                           database_mapping_synid,
+                                                           fileformat, new_tableid)
+        assert newdb.equals(expected_mapdf)
+        patch_syn_store.assert_called_once()
+
+
+def test_noname__move_entity():
+    """Tests not changing entity name"""
+    ent = synapseclient.Entity(name="foo", parentId="syn2222")
+    new_parent = "syn1234"
+    with patch.object(syn, "store") as patch_syn_store:
+        process_functions._move_entity(syn, ent, new_parent)
+        ent.parentId = new_parent
+        patch_syn_store.assert_called_once_with(ent)
+
+
+def test_name__move_entity():
+    """Tests entity name is updated"""
+    ent = synapseclient.Entity(name="foo", parentId="syn2222")
+    new_parent = "syn1234"
+    new_name = "updated name"
+    with patch.object(syn, "store") as patch_syn_store:
+        process_functions._move_entity(syn, ent, new_parent, new_name)
+        ent.parentId = new_parent
+        ent.name = new_name
+        patch_syn_store.assert_called_once_with(ent)
+
+
+def test_create_new_fileformat_table():
+    fileformat = str(uuid.uuid1())
+    db_synid = "syn1111111"
+    database_mappingdf = pd.DataFrame({'Database': [fileformat, "foo"],
+                                       "Id": [db_synid, "bar"]})
+    db_mapping_info = {'synid': 'syn666',
+                       'df': database_mappingdf}
+    table_ent = synapseclient.Entity(
+        parentId="syn123", name="foo", primaryKey=['annot'], id='syn12345'
+    )
+    project_id = "syn234"
+    archived_project_id = "syn23333"
+    new_table_name = str(uuid.uuid1())
+
+    new_table_ent = synapseclient.Entity(
+        parentId="syn123323", name="foofoo", id='syn23231'
+    )
+    update_return = Mock()
+    move_entity_return = Mock()
+    with patch.object(process_functions, "get_dbmapping",
+                      return_value=db_mapping_info) as patch_getdb,\
+         patch.object(syn, "get",
+                      return_value=table_ent) as patch_syn_get,\
+         patch.object(syn, "getTableColumns",
+                      return_value=['foo', 'ddooo']) as patch_get_table_cols,\
+         patch.object(process_functions, "_create_schema",
+                      return_value=new_table_ent) as patch_create_schema,\
+         patch.object(process_functions,
+                      "_update_database_mapping",
+                      return_value=update_return) as patch_update,\
+         patch.object(process_functions, "_move_entity",
+                      return_value=move_entity_return) as patch_move,\
+         patch.object(process_functions.time, "time", return_value=2):
+        new_table = process_functions.create_new_fileformat_table(
+            syn, fileformat, new_table_name, project_id, archived_project_id
+        )
+        patch_getdb.assert_called_once_with(syn, project_id)
+        patch_syn_get.assert_called_once_with(db_synid)
+        patch_get_table_cols.assert_called_once_with(db_synid)
+        patch_create_schema.assert_called_once_with(
+            syn, table_name=new_table_name, columns=['foo', 'ddooo'],
+            parentid=project_id, annotations=table_ent.annotations
+        )
+        patch_update.assert_called_once_with(syn, database_mappingdf,
+                                             'syn666', fileformat,
+                                             new_table_ent.id)
+        patch_move.assert_called_once_with(syn, table_ent,
+                                           archived_project_id,
+                                           name="ARCHIVED 2-foo")
+        assert new_table == {"newdb_ent": new_table_ent,
+                             "newdb_mappingdf": update_return,
+                             "moved_ent": move_entity_return}

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -1,11 +1,12 @@
 from unittest import mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
+import uuid
 
 import pandas as pd
 import pytest
 import synapseclient
 
-import synapsegenie.process_functions
+from synapsegenie import process_functions
 
 syn = mock.create_autospec(synapseclient.Synapse)
 
@@ -29,20 +30,20 @@ def test_removeStringFloat(input_str, output):
     """Remove string float - will always assume that there is a \n
     at the end.  This is because if a value was 2.01, we dont want to
     remove the .0 from this."""
-    assert synapsegenie.process_functions.removeStringFloat(input_str) == output
+    assert process_functions.removeStringFloat(input_str) == output
 
 
 def test_valid__check_valid_df():
-    synapsegenie.process_functions._check_valid_df(DATABASE_DF, "test")
+    process_functions._check_valid_df(DATABASE_DF, "test")
 
 
 def test_invalid__check_valid_df():
     with pytest.raises(ValueError, match="Must pass in pandas dataframe"):
-        synapsegenie.process_functions._check_valid_df("foo", "test")
+        process_functions._check_valid_df("foo", "test")
     with pytest.raises(
             ValueError,
             match="'error' column must exist in dataframe"):
-        synapsegenie.process_functions._check_valid_df(DATABASE_DF, "error")
+        process_functions._check_valid_df(DATABASE_DF, "error")
 
 
 def test__get_left_diff_df():
@@ -51,14 +52,14 @@ def test__get_left_diff_df():
         "test": ['test1', 'test2', 'test3', 'test4'],
         "foo": [1, 2, 3, 4],
         "baz": [float('nan'), float('nan'), float('nan'), 3.2]})
-    get_diff = synapsegenie.process_functions._get_left_diff_df(
+    get_diff = process_functions._get_left_diff_df(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     expecteddf = new_datadf.loc[[3]]
     assert get_diff.equals(expecteddf[get_diff.columns])
 
 
 def test_norows_get_left_diff_df():
-    append_rows = synapsegenie.process_functions._get_left_diff_df(
+    append_rows = process_functions._get_left_diff_df(
         DATABASE_DF, DATABASE_DF, 'UNIQUE_KEY')
     assert append_rows.empty
 
@@ -72,7 +73,7 @@ def test_first_validation_get_left_diff_df():
     with pytest.raises(
             ValueError,
             match="'FOO' column must exist in dataframe"):
-        synapsegenie.process_functions._get_left_diff_df(
+        process_functions._get_left_diff_df(
             DATABASE_DF, DATABASE_DF, 'FOO')
 
 
@@ -87,7 +88,7 @@ def test_second_validation_get_left_diff_df():
     with pytest.raises(
             ValueError,
             match="'FOO' column must exist in dataframe"):
-        synapsegenie.process_functions._get_left_diff_df(
+        process_functions._get_left_diff_df(
             testing, DATABASE_DF, 'FOO')
 
 
@@ -100,7 +101,7 @@ def test_first_validation_get_left_union_df():
     with pytest.raises(
             ValueError,
             match="'FOO' column must exist in dataframe"):
-        synapsegenie.process_functions._get_left_union_df(
+        process_functions._get_left_union_df(
             DATABASE_DF, DATABASE_DF, 'FOO')
 
 
@@ -115,7 +116,7 @@ def test_second_validation_get_left_union_df():
     with pytest.raises(
             ValueError,
             match="'FOO' column must exist in dataframe"):
-        synapsegenie.process_functions._get_left_union_df(
+        process_functions._get_left_union_df(
             testing, DATABASE_DF, 'FOO')
 
 
@@ -129,7 +130,7 @@ def test_append__append_rows():
         'test': ['test4'],
         'foo': [4],
         'baz': [3.2]})
-    append_rows = synapsegenie.process_functions._append_rows(
+    append_rows = process_functions._append_rows(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     append_rows.fillna('', inplace=True)
     expecteddf.fillna('', inplace=True)
@@ -149,7 +150,7 @@ def test___create_update_rowsdf():
         "baz": [3, 5, float('nan')]},
         index=['test1', 'test5', 'test4'])
 
-    to_update_rowsdf = synapsegenie.process_functions._create_update_rowsdf(
+    to_update_rowsdf = process_functions._create_update_rowsdf(
         database, new_datadf, DATABASE_DF.index, differentrows)
     expecteddf = pd.DataFrame({
         "test": ['test1', 'test4'],
@@ -173,7 +174,7 @@ def test_none__create_update_rowsdf():
         "baz": [3, 5, float('nan')]},
         index=['test1', 'test5', 'test4'])
 
-    to_update_rowsdf = synapsegenie.process_functions._create_update_rowsdf(
+    to_update_rowsdf = process_functions._create_update_rowsdf(
         database, new_datadf, DATABASE_DF.index, differentrows)
     assert to_update_rowsdf.empty
 
@@ -184,7 +185,7 @@ def test___get_left_union_df():
         "test": ['test', 'test2', 'test3'],
         "foo": [1, 3, 3],
         "baz": [float('nan'), 5, float('nan')]})
-    left_union = synapsegenie.process_functions._get_left_union_df(
+    left_union = process_functions._get_left_union_df(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     expecteddf = pd.DataFrame({
         'UNIQUE_KEY': ['test1'],
@@ -200,7 +201,7 @@ def test_none__get_left_union_df():
         "test": ['test', 'test2', 'test3'],
         "foo": [1, 3, 3],
         "baz": [float('nan'), 5, float('nan')]})
-    left_union = synapsegenie.process_functions._get_left_union_df(
+    left_union = process_functions._get_left_union_df(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     assert left_union.empty
 
@@ -221,7 +222,7 @@ def test_update__update_rows():
         "baz": ['', 5],
         'ROW_ID': ['1', '2'],
         'ROW_VERSION': ['3', '3']})
-    update_rows = synapsegenie.process_functions._update_rows(
+    update_rows = process_functions._update_rows(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     assert update_rows.equals(expecteddf[update_rows.columns])
 
@@ -243,7 +244,7 @@ def test_maintaintype__update_rows():
         'ROW_ID': ['2'],
         'ROW_VERSION': ['3']})
     expecteddf = expecteddf.astype({'baz': object})
-    update_rows = synapsegenie.process_functions._update_rows(
+    update_rows = process_functions._update_rows(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     assert update_rows.equals(expecteddf[update_rows.columns])
 
@@ -257,7 +258,7 @@ def test_noupdate__update_rows():
         "test": ['test'],
         "foo": [1],
         "baz": [float('nan')]})
-    update_rows = synapsegenie.process_functions._update_rows(
+    update_rows = process_functions._update_rows(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     assert update_rows.empty
 
@@ -271,13 +272,13 @@ def test_delete__delete_rows():
     expecteddf = pd.DataFrame({
         0: ['2', '3'],
         1: ['3', '5']})
-    delete_rows = synapsegenie.process_functions._delete_rows(
+    delete_rows = process_functions._delete_rows(
         new_datadf, DATABASE_DF, 'UNIQUE_KEY')
     assert delete_rows.equals(expecteddf)
 
 
 def test_norows__delete_rows():
-    delete_rows = synapsegenie.process_functions._delete_rows(
+    delete_rows = process_functions._delete_rows(
         DATABASE_DF, DATABASE_DF, 'UNIQUE_KEY')
     assert delete_rows.empty
 
@@ -299,9 +300,9 @@ def test_get_synid_database_mappingdf():
     '''
     arg = argparser()
     with patch.object(syn, "get", return_value=ENTITY), \
-         patch.object(synapsegenie.process_functions, "get_syntabledf",
+         patch.object(process_functions, "get_syntabledf",
                       return_value=arg.asDataFrame()) as patch_gettabledf:
-        df = synapsegenie.process_functions.get_synid_database_mappingdf(
+        df = process_functions.get_synid_database_mappingdf(
             syn, project_id=None)
         patch_gettabledf.assert_called_once_with(
             syn, "SELECT * FROM {}".format(ENTITY.dbMapping[0]))
@@ -316,7 +317,7 @@ def test_get_syntabledf():
     with patch.object(syn, "tableQuery",
                       return_value=arg) as patch_syn_tablequery:
         querystring = "select * from foo"
-        df = synapsegenie.process_functions.get_syntabledf(syn, querystring)
+        df = process_functions.get_syntabledf(syn, querystring)
         patch_syn_tablequery.assert_called_once_with(querystring)
         assert df.equals(arg.asDataFrame())
 

--- a/tests/test_process_functions.py
+++ b/tests/test_process_functions.py
@@ -412,7 +412,8 @@ def test_create_new_fileformat_table():
                       return_value=update_return) as patch_update,\
          patch.object(process_functions, "_move_entity",
                       return_value=move_entity_return) as patch_move,\
-         patch.object(process_functions.time, "time", return_value=2):
+         patch('synapsegenie.process_functions.date') as mock_datetime:
+        mock_datetime.today.return_value = 2
         new_table = process_functions.create_new_fileformat_table(
             syn, fileformat, new_table_name, project_id, archived_project_id
         )


### PR DESCRIPTION
This will replace an old database with new empty database with the same schema.  This will also replace the Db mapping table with the correct ids.