### PR TITLE
[ETL-215] remove list of lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,12 @@ synapsegenie process -h
 
 # only validate
 synapsegenie process --format_registry_packages example_registry \
-                     --project_id syn12345
+                     --project_id syn22337078 \
                      --only_validate
 
 # validate + process
 synapsegenie process --format_registry_packages example_registry \
-                     --project_id syn12345
+                     --project_id syn22337078
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ synapsegenie /path/to/file center_name \
 ```
 
 ### Validation/Processing
-`synapsegenie` will validate and process all the files uploaded by centers.  Every valid file will be processed and uploaded into Synapse tables.
+`synapsegenie` will validate and process all the files uploaded by centers.  Every valid file will be processed and uploaded into Synapse tables. [syn22337078](https://www.synapse.org/#!Synapse:syn22337078) is a test project.
 
 ```
 synapsegenie process -h

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This package can deploy a AACR GENIE like project on Synapse and perform validat
 ## Installation
 
 Dependencies:
-- Python 3.6 or higher
+- Python 3.7 or higher
 - [synapseclient](http://python-docs.synapse.org) (`pip install synapseclient`)
 - Python [pandas](http://pandas.pydata.org) (`pip install pandas`)
 

--- a/example_registry/csv.py
+++ b/example_registry/csv.py
@@ -13,7 +13,7 @@ class Csv(FileTypeFormat):
 
     _filetype = "csv"
 
-    _process_kwargs = ["databaseSynId"]
+    _process_kwargs = ["newPath", "databaseSynId"]
 
     def _validate_filetype(self, filePath):
         assert os.path.basename(filePath).endswith(".csv")

--- a/example_registry/csv.py
+++ b/example_registry/csv.py
@@ -16,7 +16,7 @@ class Csv(FileTypeFormat):
     _process_kwargs = ["databaseSynId"]
 
     def _validate_filetype(self, filePath):
-        assert os.path.basename(filePath[0]).endswith(".csv")
+        assert os.path.basename(filePath).endswith(".csv")
 
     def _process(self, df):
         df.columns = [df.upper() for col in df.columns]

--- a/example_registry/csv.py
+++ b/example_registry/csv.py
@@ -19,13 +19,16 @@ class Csv(FileTypeFormat):
         assert os.path.basename(filePath).endswith(".csv")
 
     def _process(self, df):
-        df.columns = [df.upper() for col in df.columns]
+        df.columns = [col.upper() for col in df.columns]
         return df
 
     def process_steps(self, df, newPath, databaseSynId):
         df = self._process(df)
-        process_functions.updateData(self.syn, databaseSynId, df, self.center,
-                                     toDelete=True)
+        # TODO: no center column in Synapse table
+        # process_functions.update_data(
+        #     syn=self.syn, databaseSynId=databaseSynId, newData=df,
+        #     filterBy=self.center, toDelete=True
+        # )
         df.to_csv(newPath, sep="\t", index=False)
         return newPath
 

--- a/synapsegenie/__main__.py
+++ b/synapsegenie/__main__.py
@@ -91,13 +91,11 @@ def validate_single_file_cli_wrapper(syn, args):
         args.format_registry_packages
     )
     logger.debug(f"Using {format_registry} file formats.")
-    entity_list = [synapseclient.File(name=filepath, path=filepath,
-                                      parentId=None)
-                   for filepath in args.filepath]
+    entity = synapseclient.File(name=args.filepath, path=args.filepath, parentId=None)
 
     validator = validator_cls(syn=syn, project_id=args.project_id,
                               center=args.center,
-                              entitylist=entity_list,
+                              entity=entity,
                               format_registry=format_registry,
                               file_type=args.filetype)
     mykwargs = dict(project_id=args.project_id)

--- a/synapsegenie/example_filetype_format.py
+++ b/synapsegenie/example_filetype_format.py
@@ -71,7 +71,7 @@ class FileTypeFormat:
         self._validate_filetype(filePath)
         return self._filetype
 
-    def process_steps(self, df, **kwargs):
+    def process_steps(self, path_or_df, **kwargs):
         '''
         This function is modified for every single file.
         It reformats the file and stores the file into database and Synapse.
@@ -108,7 +108,7 @@ class FileTypeFormat:
                 "%s not in parameter list" % required_parameter
             mykwargs[required_parameter] = kwargs[required_parameter]
         logger.info('PROCESSING %s' % filePath)
-        path_or_df = self.read_file([filePath])
+        path_or_df = self.read_file(filePath)
         path = self.process_steps(path_or_df, **mykwargs)
         return path
 

--- a/synapsegenie/example_filetype_format.py
+++ b/synapsegenie/example_filetype_format.py
@@ -18,7 +18,7 @@ class FileTypeFormat:
         self.syn = syn
         self.center = center
 
-    def _get_dataframe(self, filePathList):
+    def _get_dataframe(self, filePath):
         '''
         This function by defaults assumes the filePathList is length of 1
         and is a tsv file.  Could change depending on file type.
@@ -30,11 +30,10 @@ class FileTypeFormat:
         Returns:
             df: Pandas dataframe of file
         '''
-        filePath = filePathList[0]
         df = pd.read_csv(filePath, sep="\t", comment="#")
         return df
 
-    def read_file(self, filePathList):
+    def read_file(self, filePath):
         '''
         Each file is to be read in for validation and processing.
         This is not to be changed in any functions.
@@ -46,7 +45,7 @@ class FileTypeFormat:
         Returns:
             df: Pandas dataframe of file
         '''
-        df = self._get_dataframe(filePathList)
+        df = self._get_dataframe(filePath)
         return df
 
     def _validate_filetype(self, filePath):
@@ -131,13 +130,13 @@ class FileTypeFormat:
         logger.info(f"NO VALIDATION for {self._filetype} files")
         return errors, warnings
 
-    def validate(self, filePathList, **kwargs):
+    def validate(self, filePath, **kwargs):
         '''
         This is the main validation function.
         Every file type calls self._validate, which is different.
 
         Args:
-            filePathList: A list of file paths.
+            filePath: A list of file paths.
             kwargs: The kwargs are determined by self._validation_kwargs
 
         Returns:
@@ -152,16 +151,14 @@ class FileTypeFormat:
         errors = ""
 
         try:
-            df = self.read_file(filePathList)
+            df = self.read_file(filePath)
         except Exception as e:
-            errors = (f"The file(s) ({filePathList}) cannot be read. "
+            errors = (f"The file(s) ({filePath}) cannot be read. "
                       f"Original error: {str(e)}")
             warnings = ""
 
         if not errors:
-            logger.info("VALIDATING {}".format(
-                os.path.basename(",".join(filePathList))
-            ))
+            logger.info(f"VALIDATING {os.path.basename(filePath)}")
             errors, warnings = self._validate(df, **mykwargs)
         # File is valid if error string is blank
         valid = (errors == '')

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -155,7 +155,7 @@ def _send_validation_error_email(syn, user, message_objs):
                     messageSubject=f"GENIE Validation Error - {date_now}",
                     messageBody=email_message)
 
-
+# TODO: update this function
 def _get_status_and_error_list(valid, message, entity):
     '''
     Helper function to return the status and error list of the
@@ -227,6 +227,7 @@ def validatefile(syn, project_id, entity, validation_status_table,
     if check_file_status['to_validate']:
         valid, message = validator.validate_single_file()
         logger.info("VALIDATION COMPLETE")
+        # TODO: update this
         input_status_list, invalid_errors_list = _get_status_and_error_list(
             valid, message, entity
         )

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -565,7 +565,8 @@ def validation(syn, project_id, center, center_files,
             center=center,
             format_registry=format_registry,
             validator_cls=validator_cls)
-
+        # TODO: remove return as a tuple of list of dicts so no need
+        # to extend soon.
         input_valid_statuses.extend(status)
         if errors is not None:
             invalid_errors.extend(errors)

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -660,9 +660,8 @@ def center_input_to_database(syn, project_id, center,
     center_input_synid = center_mapping_df['inputSynId'][
         center_mapping_df['center'] == center][0]
     logger.info(f"Center: {center}")
-    # TODO: can probably remove the center parameter and move the
-    # print statement out of this function.
     logger.info(f"GETTING {center} INPUT FILES")
+    # TODO: Rename function
     center_files = get_center_input_files(syn, center_input_synid)
 
     # only validate if there are center files

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -264,14 +264,19 @@ def processfiles(syn, validfiles, center, path_to_genie,
     """
     logger.info(f"PROCESSING {center} FILES: {len(validfiles)}")
     center_staging_folder = os.path.join(path_to_genie, center)
-    center_staging_synid = center_mapping_df.query(
-        f"center == '{center}'").stagingSynId.iloc[0]
+    # TODO: determine if staging folder is important...
+    # center_staging_synid = center_mapping_df.query(
+    #     f"center == '{center}'").stagingSynId.iloc[0]
 
     if not os.path.exists(center_staging_folder):
         os.makedirs(center_staging_folder)
 
     for _, row in validfiles.iterrows():
         filetype = row['fileType']
+        # Added per data folder
+        data_folder_synid = databaseToSynIdMappingDf.Id[
+            databaseToSynIdMappingDf['Database'] == f"{filetype}_folder"
+        ]
         # filename = os.path.basename(filePath)
         newpath = os.path.join(center_staging_folder, row['name'])
         # store = True
@@ -288,7 +293,7 @@ def processfiles(syn, validfiles, center, path_to_genie,
             processor = format_registry[filetype](syn, center)
             processor.process(
                 filePath=row['path'], newPath=newpath,
-                parentId=center_staging_synid, databaseSynId=tableid,
+                parentId=data_folder_synid, databaseSynId=tableid,
                 fileSynId=row['id'],
                 databaseToSynIdMappingDf=databaseToSynIdMappingDf
             )

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -36,11 +36,10 @@ def entity_date_to_timestamp(entity_date_time):
                                                "%Y-%m-%dT%H:%M:%S")
     return to_unix_epoch_time(date_time_obj)
 
-
+# TODO: rename function
 def get_center_input_files(
         syn: synapseclient.Synapse,
         synid: str,
-        center: str,
         downloadFile: bool = True
     ) -> List[synapseclient.Entity]:
     """Walks through each center's input directory to get a
@@ -49,15 +48,11 @@ def get_center_input_files(
     Args:
         syn: Synapse object
         synid: Center input folder synid
-        center: Center name
         downloadFile: To download files. Default is True.
 
     Returns:
         list: List of Synapse Entities per center.
     """
-    # TODO: can probably remove the center parameter and move the
-    # print statement out of this function.
-    logger.info(f"GETTING {center} INPUT FILES")
     center_files = synapseutils.walk(syn, synid)
     prepared_center_file_list = []
 
@@ -665,7 +660,10 @@ def center_input_to_database(syn, project_id, center,
     center_input_synid = center_mapping_df['inputSynId'][
         center_mapping_df['center'] == center][0]
     logger.info(f"Center: {center}")
-    center_files = get_center_input_files(syn, center_input_synid, center)
+    # TODO: can probably remove the center parameter and move the
+    # print statement out of this function.
+    logger.info(f"GETTING {center} INPUT FILES")
+    center_files = get_center_input_files(syn, center_input_synid)
 
     # only validate if there are center files
     if center_files:

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -87,6 +87,7 @@ def check_existing_file_status(validation_status_table, error_tracker_table,
             to_validate: Boolean value for whether of not an input
                          file needs to be validated
     '''
+    # TODO: check if entity is passed in
     # if len(entity) > 2:
     #     raise ValueError(
     #         "There should never be more than 2 files being validated.")

--- a/synapsegenie/input_to_database.py
+++ b/synapsegenie/input_to_database.py
@@ -90,18 +90,17 @@ def check_existing_file_status(validation_status_table, error_tracker_table,
     # if len(entity) > 2:
     #     raise ValueError(
     #         "There should never be more than 2 files being validated.")
+    status = ""
+    error = ""
 
     validation_statusdf = validation_status_table.asDataFrame()
     error_trackerdf = error_tracker_table.asDataFrame()
     # This should be outside fo the forloop so that it doesn't
     # get reset
     to_validate = False
-    #for ent in entities:
     # Get the current status and errors from the tables.
     current_status = validation_statusdf[validation_statusdf['id'] == entity.id]
     current_error = error_trackerdf[error_trackerdf['id'] == entity.id]
-    status = ""
-    error = ""
     if current_status.empty:
         to_validate = True
     else:

--- a/synapsegenie/validate.py
+++ b/synapsegenie/validate.py
@@ -13,7 +13,7 @@ class ValidationHelper:
     # Overload this per class
     _validate_kwargs = []
 
-    def __init__(self, syn, project_id, center, entitylist,
+    def __init__(self, syn, project_id, center, entity,
                  format_registry=None, file_type=None):
         """A validator helper class for a center's files.
 
@@ -29,7 +29,7 @@ class ValidationHelper:
         """
         self._synapse_client = syn
         self._project = syn.get(project_id)
-        self.entitylist = entitylist
+        self.entity = entity
         self.center = center
         self._format_registry = format_registry
         self.file_type = (self.determine_filetype()
@@ -53,8 +53,8 @@ class ValidationHelper:
                 self._synapse_client, self.center
             )
             try:
-                filenames = [entity.name for entity in self.entitylist]
-                filetype = validator.validate_filetype(filenames)
+                filename = self.entity.name
+                filetype = validator.validate_filetype(filename)
             except AssertionError:
                 continue
             # If valid filename, return file type.
@@ -86,9 +86,9 @@ class ValidationHelper:
 
             validator_cls = self._format_registry[self.file_type]
             validator = validator_cls(self._synapse_client, self.center)
-            filepathlist = [entity.path for entity in self.entitylist]
+            # filepathlist = [entity.path for entity in self.entitylist]
             valid, errors, warnings = validator.validate(
-                filePathList=filepathlist, **mykwargs
+                filePath=self.entity.path, **mykwargs
             )
 
         # Complete error message

--- a/tests/test_input_to_database.py
+++ b/tests/test_input_to_database.py
@@ -141,7 +141,7 @@ def test_get_center_input_files():
          patch.object(syn, "get",
                       side_effect=syn_get_effects) as patch_syn_get:
         center_file_list = input_to_database.get_center_input_files(
-            syn, "syn12345", center,
+            syn, "syn12345"
         )
         assert len(center_file_list) == len(expected_center_file_list)
         assert center_file_list == expected_center_file_list
@@ -156,8 +156,7 @@ def test_empty_get_center_input_files():
     '''
     with patch.object(synapseutils, "walk",
                       return_value=walk_return_empty()) as patch_synapseutils_walk:
-        center_file_list = input_to_database.get_center_input_files(
-            syn, "syn12345", center)
+        center_file_list = input_to_database.get_center_input_files(syn, "syn12345")
         assert center_file_list == []
         patch_synapseutils_walk.assert_called_once_with(syn, 'syn12345')
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -39,11 +39,10 @@ def test_perfect_determine_filetype():
     Parameters are passed in from filename_fileformat_map
     """
     filetype = "clincial"
-    ent_list = [SAMPLE_ENT]
     with patch.object(FileFormat, "validate_filetype",
                       return_value=filetype):
         validator = validate.ValidationHelper(
-            syn, None, CENTER, ent_list,
+            syn, None, CENTER, SAMPLE_ENT,
             format_registry={filetype: FileFormat}
         )
         assert validator.determine_filetype() == filetype
@@ -54,12 +53,11 @@ def test_wrongfilename_noerror_determine_filetype():
     Tests None is passed back when wrong filename is passed
     when raise_error flag is False
     '''
-    ent_list = [WRONG_NAME_ENT]
     with patch.object(FileFormat, "validate_filetype",
                       side_effect=AssertionError):
         validator = validate.ValidationHelper(
             syn, project_id=None,
-            center=CENTER, entitylist=ent_list,
+            center=CENTER, entity=WRONG_NAME_ENT,
             format_registry={"wrong": FileFormat})
         assert validator.determine_filetype() is None
 
@@ -105,7 +103,6 @@ def test_valid_validate_single_file():
     Tests that all the functions are run in validate single
     file workflow and all the right things are returned
     """
-    entitylist = [CLIN_ENT]
     error_string = ''
     warning_string = ''
     expected_valid = True
@@ -122,7 +119,7 @@ def test_valid_validate_single_file():
                       return_value=expected_message) as mock_determine:
         validator = validate.ValidationHelper(
             syn, project_id="syn1234", center=CENTER,
-            entitylist=entitylist, format_registry={'clinical': FileFormat}
+            entity=CLIN_ENT, format_registry={'clinical': FileFormat}
         )
         valid, message = validator.validate_single_file(oncotree_link=None,
                                                         nosymbol_check=False)
@@ -133,7 +130,7 @@ def test_valid_validate_single_file():
 
         mock_determine_ftype.assert_called_once_with()
 
-        mock_genie_class.assert_called_once_with(filePathList=[CLIN_ENT.path])
+        mock_genie_class.assert_called_once_with(filePath=CLIN_ENT.path)
 
         mock_determine.assert_called_once_with(error_string, warning_string)
 
@@ -143,7 +140,6 @@ def test_filetype_validate_single_file():
     Tests that if filetype is passed in that an error is thrown
     if it is an incorrect filetype
     """
-    entitylist = [WRONG_NAME_ENT]
     expected_error = ("----------------ERRORS----------------\n"
                       "Your filename is incorrect! Please change your "
                       "filename before you run the validator or specify "
@@ -152,7 +148,7 @@ def test_filetype_validate_single_file():
     with patch.object(FileFormat, "validate_filetype",
                       side_effect=AssertionError):
         validator = validate.ValidationHelper(
-            syn=syn, project_id=None, center=CENTER, entitylist=entitylist,
+            syn=syn, project_id=None, center=CENTER, entity=WRONG_NAME_ENT,
             format_registry={'wrong': FileFormat}
         )
 
@@ -166,7 +162,6 @@ def test_wrongfiletype_validate_single_file():
     Tests that if there is no filetype for the filename passed
     in, an error is thrown
     """
-    entitylist = [WRONG_NAME_ENT]
     expected_error = ('----------------ERRORS----------------\n'
                       'Your filename is incorrect! Please change your '
                       'filename before you run the validator or specify '
@@ -176,7 +171,7 @@ def test_wrongfiletype_validate_single_file():
                       "determine_filetype",
                       return_value=None) as mock_determine_filetype:
         validator = validate.ValidationHelper(
-            syn=syn, project_id=None, center=CENTER, entitylist=entitylist,
+            syn=syn, project_id=None, center=CENTER, entity=WRONG_NAME_ENT,
             format_registry={'wrong': Mock()}
         )
         valid, message = validator.validate_single_file()


### PR DESCRIPTION
`get_center_input_files` used to return a list of lists to support validation across multiple files.  This has been removed to simplify the code.  A list of entities is now returned.